### PR TITLE
Add Flask templates and item detail routing

### DIFF
--- a/backend/routes/items.py
+++ b/backend/routes/items.py
@@ -159,3 +159,20 @@ def get_categories():
         'category_count': len(result),
         'categories': result
     }), 200
+
+
+@items_bp.route('/<int:item_id>', methods=['GET'])
+def get_item(item_id):
+    item = Item.query.get_or_404(item_id)
+    return jsonify({
+        'id': item.id,
+        'title': item.title,
+        'description': item.description,
+        'price': str(item.price),
+        'posted_by': item.posted_by,
+        'date_posted': item.date_posted.isoformat(),
+        'categories': [{'name': c.name} for c in item.categories],
+        'star_rating': item.star_rating,
+        'review_count': item.reviews.count()
+    }), 200
+

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Bellashop</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+    .item-title-link {
+        transition: transform 0.2s, text-shadow 0.2s;
+    }
+    .item-title-link:hover {
+        transform: scale(1.05);
+        text-shadow: 0 0 5px rgba(0,0,0,0.3);
+        text-decoration: none;
+    }
+    </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('home') }}">Bellashop</a>
+    <form class="d-flex ms-auto me-3">
+      <input class="form-control" type="search" placeholder="Search" aria-label="Search">
+    </form>
+    <ul class="navbar-nav mb-2 mb-lg-0">
+      <li class="nav-item"><a class="nav-link" href="#">Item Management</a></li>
+      <li class="nav-item"><a class="nav-link" href="{{ url_for('profile') }}">Profile</a></li>
+    </ul>
+  </div>
+</nav>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Items</h1>
+<div class="row row-cols-1 gy-3">
+  {% for item in items %}
+  <div class="col">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">
+          <a href="{{ url_for('item_detail', item_id=item.id) }}" class="item-title-link">{{ item.title }}</a>
+        </h5>
+        <p class="card-text">Categories: {{ item.categories|join(', ') }}</p>
+        <p class="card-text">
+          <a href="{{ url_for('item_detail', item_id=item.id) }}" class="text-decoration-none text-warning">
+            {{ '★' * (item.star_rating|round(0,'floor')|int) }}{{ '☆' * (5-(item.star_rating|round(0,'floor')|int)) }}
+            ({{ item.review_count }} reviews)
+          </a>
+        </p>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/backend/templates/item_detail.html
+++ b/backend/templates/item_detail.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ item.title }}</h1>
+<p>Categories: {{ categories|join(', ') }}</p>
+<p>Rating: {{ item.star_rating }}/5 ({{ review_count }} reviews)</p>
+<p>{{ item.description }}</p>
+{% endblock %}

--- a/backend/templates/profile.html
+++ b/backend/templates/profile.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>User Profile</h1>
+<p>This is a placeholder profile page.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Flask templates with a navigation bar
- list items on the home page and link to item detail
- implement `/item/<id>` and `/profile` routes
- provide API endpoint to fetch single item

## Testing
- `python -m py_compile backend/app.py backend/routes/items.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688c44a1bdc4832399328064e1c9b0d9