### PR TITLE
Set user to null on app launch for better session handling

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -10,8 +10,16 @@ export default function Navbar() {
   useEffect(() => {
     fetch('/api/auth/status', { credentials: 'include' })
       .then(res => (res.ok ? res.json() : null))
-      .then(data => setUser(data))
-      .catch(() => {});
+      .then (data => {
+        if (data && data.id) {
+          setUser(data);  // Only set a user if /api/auth/status returns all user data
+        } else {
+          setUser(null);
+        }
+      })
+      .catch(() => {
+        setUser(null);  // Explicityly set user to null on any error
+      });
   }, []);
 
   const handleLogout = async () => {


### PR DESCRIPTION
Ensure the user state is explicitly set to null on app launch and in case of errors, preventing incorrect user session data from being used.